### PR TITLE
Document the API stability / maintenance policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Notes for AI assistants working in `u-authorization`.
 
+## Golden rule: feature-complete, keep it running
+
+`u-authorization` is feature-complete. There are no plans to add new features. The only ongoing work is keeping the gem compatible and running on current and future Ruby versions, plus the usual bug fixes, docs, and CI upkeep.
+
+That means two things for any task here:
+
+- **Don't add features or change the public API.** The API is frozen and backward compatible. If a task as stated would require a new feature or a breaking change, stop and surface that, then propose a compatibility-only path.
+- **Major version bumps are for dependency-floor changes only** (dropping an old Ruby from the supported matrix) per SemVer. They do not signal a behavior break. Note that this gem is pure Ruby with no ActiveModel dependency, so the support matrix is Ruby-only.
+
 ## How to work in this repo
 
 ### 1. Think before coding

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 Authorization and role management for Ruby, with no runtime dependencies.
 
+> [!IMPORTANT]
+> **Stable and feature-complete.** `u-authorization` has no new features planned. Its public API is frozen and backward compatible, and ongoing work is limited to keeping it running on current and future Ruby versions. You can depend on it without expecting breaking changes.
+>
+> A major version bump signals only that an old Ruby version was dropped from the supported matrix, which is a dependency-floor change under SemVer. Your code keeps working.
+
 `u-authorization` splits authorization into two layers that you can use together or on their own:
 
 1. **Permissions** answer "is this role allowed to use this feature, in this context?". A role is plain data (a Hash, or JSON loaded from a database), so you can change who can do what without redeploying.


### PR DESCRIPTION
Documents that `u-authorization` is feature-complete and in maintenance mode, mirroring the stability notice in the sibling `u-gems` (adapted to this gem's situation).

## Changes
- **README**: adds an `[!IMPORTANT]` notice at the top stating the gem is stable and feature-complete, its public API is frozen and backward compatible, and ongoing work is limited to keeping it running on current and future Ruby versions. Major version bumps signal only a dependency-floor change (dropping an old Ruby) under SemVer.
- **CLAUDE.md**: adds a matching "Golden rule: feature-complete, keep it running" section so future contributors (human or AI) scope work to compatibility, bug fixes, docs, and CI rather than new features or API changes.

## Adapted, not copied
The `u-attributes` version of this notice justifies the freeze as "a runtime dependency of `u-case`." That is not true here: `u-authorization` is a standalone gem and is pure Ruby with no ActiveModel dependency. The wording reflects that (Ruby-only support matrix, maintenance-mode framing) and is kept free of em dashes to match the README's style.

Docs only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)