### PR TITLE
Center README header and badges (match u-struct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-[![Gem](https://img.shields.io/gem/v/u-authorization.svg?style=flat-square)](https://rubygems.org/gems/u-authorization)
-[![Build Status](https://github.com/serradura/u-authorization/actions/workflows/ci.yml/badge.svg)](https://github.com/serradura/u-authorization/actions/workflows/ci.yml)
-[![Maintainability](https://qlty.sh/gh/serradura/projects/u-authorization/maintainability.svg)](https://qlty.sh/gh/serradura/projects/u-authorization)
-[![Code Coverage](https://qlty.sh/gh/serradura/projects/u-authorization/coverage.svg)](https://qlty.sh/gh/serradura/projects/u-authorization)
-<br/>
-![Ruby](https://img.shields.io/badge/Ruby%20%3E%3D%202.7%2C%20%3C%3D%20Head-ruby.svg?colorA=444&colorB=333)
-![Rails](https://img.shields.io/badge/Rails%20%3E%3D%206.0-rails.svg?colorA=444&colorB=333)
+<p align="center">
+  <h1 align="center">🔐 µ-authorization</h1>
+  <p align="center"><i>Authorization and role management for Ruby, with no runtime dependencies.</i></p>
+</p>
 
-# µ-authorization
-
-Authorization and role management for Ruby, with no runtime dependencies.
+<p align="center">
+  <a href="https://rubygems.org/gems/u-authorization">
+    <img alt="Gem" src="https://img.shields.io/gem/v/u-authorization.svg?style=flat-square">
+  </a>
+  <a href="https://github.com/serradura/u-authorization/actions/workflows/ci.yml">
+    <img alt="Build Status" src="https://github.com/serradura/u-authorization/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <br/>
+  <a href="https://qlty.sh/gh/serradura/projects/u-authorization"><img src="https://qlty.sh/gh/serradura/projects/u-authorization/maintainability.svg" alt="Maintainability" /></a>
+  <a href="https://qlty.sh/gh/serradura/projects/u-authorization"><img src="https://qlty.sh/gh/serradura/projects/u-authorization/coverage.svg" alt="Code Coverage" /></a>
+  <br/>
+  <img src="https://img.shields.io/badge/Ruby%20%3E%3D%202.7%2C%20%3C%3D%20Head-ruby.svg?colorA=444&colorB=333" alt="Ruby">
+  <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0-rails.svg?colorA=444&colorB=333" alt="Rails">
+</p>
 
 > [!IMPORTANT]
 > **Stable and feature-complete.** `u-authorization` has no new features planned. Its public API is frozen and backward compatible, and ongoing work is limited to keeping it running on current and future Ruby versions. You can depend on it without expecting breaking changes.


### PR DESCRIPTION
Restructures the README title and badge row into the centered HTML layout used by the sibling `u-gems` (matching the `u-struct` pattern).

## Changes
- Centered title block: `🔐 µ-authorization` plus the italic tagline.
- Centered badge block: Gem and Build Status (multi-line `<a><img>`), Qlty maintainability + coverage, and the Ruby / Rails badges, split by `<br/>`.
- Everything below the header (stability notice, body, sections) is unchanged. No internal links pointed at the old title anchor, so nothing breaks.

## Notes on choices (vs the u-struct template)
- **Emoji 🔐** picked for this gem (it had no logo/emoji of its own). Easy to change.
- **Rails badge kept as `Rails >= 6.0`** rather than u-struct's `>= 6.0, <= Edge`: u-authorization is pure Ruby with no Rails/ActiveModel dependency and no Rails CI matrix, so an "up to Edge" claim would be inaccurate.
- **Kept the `µ` glyph** from the existing title (visually identical to u-struct's `μ`).

Docs only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)